### PR TITLE
fix: textValue of row will be used for getKeyForSearch

### DIFF
--- a/packages/@react-aria/table/src/TableKeyboardDelegate.ts
+++ b/packages/@react-aria/table/src/TableKeyboardDelegate.ts
@@ -178,6 +178,13 @@ export class TableKeyboardDelegate<T> extends GridKeyboardDelegate<T, TableColle
         return null;
       }
 
+      if (item.textValue) {
+        let substring = item.textValue.slice(0, search.length);
+        if (this.collator.compare(substring, search) === 0) {
+          return item.key;
+        }
+      }
+
       // Check each of the row header cells in this row for a match
       for (let cell of getChildNodes(item, this.collection)) {
         let column = collection.columns[cell.index];

--- a/packages/react-aria-components/src/Table.tsx
+++ b/packages/react-aria-components/src/Table.tsx
@@ -912,7 +912,7 @@ export interface TableBodyRenderProps {
   isDropTarget: boolean
 }
 
-export interface TableBodyProps<T> extends CollectionProps<T>, StyleRenderProps<TableBodyRenderProps> {
+export interface TableBodyProps<T> extends Omit<CollectionProps<T>, 'disabledKeys'>, StyleRenderProps<TableBodyRenderProps> {
   /** Provides content to display when there are no rows in the table. */
   renderEmptyState?: (props: TableBodyRenderProps) => ReactNode
 }


### PR DESCRIPTION
### Why
- the `textValue` prop of `<Row />` should be used for the `getKeyForSearch` function to focus a row.
- The `disabledKeys` prop of `<TableBody />` is unnecessary and should be removed.

### How
- check for `textValue` prop of row and if match return the item key. Should be checked before cell.
- Omit `disabledKeys` from the extended `CollectionProps`